### PR TITLE
Better error handling

### DIFF
--- a/buster/busterbot.py
+++ b/buster/busterbot.py
@@ -130,8 +130,8 @@ class Buster:
 
         return matched_documents
 
-    def check_response_relevance(
-        self, completion_text: str, engine: str, unk_embedding: np.array, unk_threshold: float
+    def check_completion_relevance(
+        self, completion: Completion, engine: str, unk_embedding: np.array, unk_threshold: float
     ) -> bool:
         """Check to see if a response is relevant to the chatbot's knowledge or not.
 
@@ -140,8 +140,13 @@ class Buster:
 
         set the unk_threshold to 0 to essentially turn off this feature.
         """
+
+        if completion.error:
+            # consider not relevant if an error occured
+            return False
+
         response_embedding = self.get_embedding(
-            completion_text,
+            completion.text,
             engine=engine,
         )
         score = cosine_similarity(response_embedding, unk_embedding)
@@ -184,17 +189,17 @@ class Buster:
         logger.info(f"GPT Response:\n{completion.text}")
 
         # check for relevance
-        is_relevant = self.check_response_relevance(
-            completion_text=completion.text,
+        is_relevant = self.check_completion_relevance(
+            completion=completion,
             engine=self.embedding_model,
             unk_embedding=self.unk_embedding,
             unk_threshold=self.unknown_threshold,
         )
         if not is_relevant:
-            matched_documents = pd.DataFrame(columns=matched_documents.columns)
-            # answer generated was the chatbot saying it doesn't know how to answer
-        # uncomment override completion with unknown prompt
-        # completion = Completion(text=self.unknown_prompt)
+            # answer generated was the chatbot saying it doesn't know how to answer or an error
+            matched_documents = pd.DataFrame(columns=matched_documents.columns)  # empty dataframe
+            # uncomment to override completion with unknown prompt
+            # completion = Completion(text=self.unknown_prompt)
 
         response = Response(
             completion=completion, matched_documents=matched_documents, is_relevant=is_relevant, user_input=user_input

--- a/buster/busterbot.py
+++ b/buster/busterbot.py
@@ -145,6 +145,9 @@ class Buster:
             # consider not relevant if an error occured
             return False
 
+        if completion.text == "":
+            raise ValueError("Cannot compute embedding of an empty string.")
+
         response_embedding = self.get_embedding(
             completion.text,
             engine=engine,

--- a/buster/busterbot.py
+++ b/buster/busterbot.py
@@ -8,7 +8,7 @@ from openai.embeddings_utils import cosine_similarity, get_embedding
 
 from buster.completers import completer_factory
 from buster.completers.base import Completion
-from buster.formatters.prompts import SystemPromptFormatter, prompt_formatter_factory
+from buster.formatters.prompts import prompt_formatter_factory
 from buster.retriever import Retriever
 
 logger = logging.getLogger(__name__)
@@ -140,9 +140,8 @@ class Buster:
 
         set the unk_threshold to 0 to essentially turn off this feature.
         """
-
         if completion.error:
-            # consider not relevant if an error occured
+            # considered not relevant if an error occured
             return False
 
         if completion.text == "":
@@ -198,11 +197,10 @@ class Buster:
             unk_embedding=self.unk_embedding,
             unk_threshold=self.unknown_threshold,
         )
+
         if not is_relevant:
-            # answer generated was the chatbot saying it doesn't know how to answer or an error
-            matched_documents = pd.DataFrame(columns=matched_documents.columns)  # empty dataframe
-            # uncomment to override completion with unknown prompt
-            # completion = Completion(text=self.unknown_prompt)
+            empty_documents = pd.DataFrame(columns=matched_documents.columns)
+            matched_documents = empty_documents
 
         response = Response(
             completion=completion, matched_documents=matched_documents, is_relevant=is_relevant, user_input=user_input

--- a/buster/completers/base.py
+++ b/buster/completers/base.py
@@ -46,7 +46,7 @@ class Completer(ABC):
         except Exception as e:
             # log the error and return a generic response instead.
             logger.exception("Error connecting to OpenAI API. See traceback:")
-            return Completion("", True, "We're having trouble connecting to OpenAI right now... Try again soon!")
+            return Completion("Something went wrong, try again soon!", True, "Error detected at the generate_response level")
 
         return Completion(completion)
 

--- a/buster/completers/base.py
+++ b/buster/completers/base.py
@@ -43,10 +43,13 @@ class Completer(ABC):
         logger.info(f"{user_input=}")
         try:
             completion = self.complete(prompt=prompt, **self.completion_kwargs)
+        except openai.error.InvalidRequestError:
+            logger.exception("Error connecting to OpenAI API. See traceback:")
+            return Completion("Something went wrong, try again soon!", True, "Invalid request made to openai.")
         except Exception as e:
             # log the error and return a generic response instead.
             logger.exception("Error connecting to OpenAI API. See traceback:")
-            return Completion("Something went wrong, try again soon!", True, "Error detected at the generate_response level")
+            return Completion("Something went wrong, try again soon!", True, "Unexpected error at the generate_response level")
 
         return Completion(completion)
 

--- a/buster/completers/base.py
+++ b/buster/completers/base.py
@@ -49,7 +49,9 @@ class Completer(ABC):
         except Exception as e:
             # log the error and return a generic response instead.
             logger.exception("Error connecting to OpenAI API. See traceback:")
-            return Completion("Something went wrong, try again soon!", True, "Unexpected error at the generate_response level")
+            return Completion(
+                "Something went wrong, try again soon!", True, "Unexpected error at the generate_response level"
+            )
 
         return Completion(completion)
 


### PR DESCRIPTION
Errors would fail silently before because the completion was being returned with an empty string, and we were trying to compute the embedding of an empty string.