### PR TITLE
ignore errors when dropping columns

### DIFF
--- a/buster/completers/base.py
+++ b/buster/completers/base.py
@@ -88,7 +88,7 @@ class Completion:
 
         def encode_df(df: pd.DataFrame) -> dict:
             if columns_to_ignore is not None:
-                df = df.drop(columns=columns_to_ignore)
+                df = df.drop(columns=columns_to_ignore, errors='ignore')
             return df.to_json(orient="index")
 
         custom_encoder = {

--- a/buster/completers/base.py
+++ b/buster/completers/base.py
@@ -88,7 +88,7 @@ class Completion:
 
         def encode_df(df: pd.DataFrame) -> dict:
             if columns_to_ignore is not None:
-                df = df.drop(columns=columns_to_ignore, errors='ignore')
+                df = df.drop(columns=columns_to_ignore, errors="ignore")
             return df.to_json(orient="index")
 
         custom_encoder = {


### PR DESCRIPTION
It's expected to not always have the referenced columns, in the case for example of an empty dataframe returned. Allow for this