### PR TITLE
quickfix: use answer_text instead of answer_generator from now on

### DIFF
--- a/buster/busterbot.py
+++ b/buster/busterbot.py
@@ -102,7 +102,7 @@ class Buster:
                 error=False,
                 user_input=user_input,
                 matched_documents=pd.DataFrame(),
-                answer_generator=irrelevant_question_message,
+                answer_text=irrelevant_question_message,
                 answer_relevant=False,
                 question_relevant=False,
                 validator=self.validator,

--- a/buster/completers/base.py
+++ b/buster/completers/base.py
@@ -237,7 +237,7 @@ class Completer(ABC):
             # because we are proceeding with a completion, we assume the question is relevant.
             completion = self.completion_class(
                 user_input=user_input,
-                answer_generator=self.no_documents_message,
+                answer_text=self.no_documents_message,
                 error=False,
                 matched_documents=matched_documents,
                 question_relevant=question_relevant,

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -82,7 +82,7 @@ class MockCompleter(Completer):
 
     def get_completion(self, user_input, matched_documents, validator, *arg, **kwarg) -> Completion:
         return Completion(
-            answer_generator=self.expected_answer,
+            answer_text=self.expected_answer,
             error=False,
             user_input=user_input,
             matched_documents=matched_documents,

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -29,7 +29,7 @@ def test_read_write_completion():
     c = Completion(
         user_input="What is the meaning of life?",
         error=False,
-        answer_generator="This is my actual answer",
+        answer_text="This is my actual answer",
         matched_documents=matched_documents,
         validator=MockValidator(),
     )


### PR DESCRIPTION
make it more explicit when passing a generator vs. a string of text